### PR TITLE
check if slot is named before accessing it's name

### DIFF
--- a/src/components/VsaItem.js
+++ b/src/components/VsaItem.js
@@ -101,7 +101,8 @@ export default {
     getComponent(name) {
       try {
         const wrapper = this.$slots.default.find((slot) => {
-          return new slot.componentOptions.Ctor().$options.name === name;
+          if (slot.componentOptions != undefined)
+            return new slot.componentOptions.Ctor().$options.name === name;
         });
 
         if (!wrapper) {


### PR DESCRIPTION
This prevents empty content nodes in the accordion when using it as a umd library